### PR TITLE
Ems sidebarbug relog date

### DIFF
--- a/Components/SessionLogger.js
+++ b/Components/SessionLogger.js
@@ -79,7 +79,7 @@ export const SessionLogger = ({isCheckpoint, initSessionData, trainerSessionSele
             }
         } else {
             const dateMilliseconds = sessionDate.getTime()
-            let tempSessionData = initSessionData;
+            let tempSessionData = JSON.parse(JSON.stringify(initSessionData));
             tempSessionData.measurements = measurementData;
             let res = await logTrainerSession(tempSessionData, dateMilliseconds)
             setLogged(true);
@@ -137,6 +137,30 @@ export const SessionLogger = ({isCheckpoint, initSessionData, trainerSessionSele
             setLogged(true)
         }
         setMeasurementData(newMeasurementData);
+    }
+
+    const confirmDate = () => {
+        setIsDateConfirmModalVisible(false);
+        setSessionDate(newSessionDate);
+
+        const dateVal = parseInt(initSessionData['initialLogDate']);
+        const initialLogDate = new Date(dateVal)
+
+        // check if the new date is different from the previously logged date
+        if (isSameDate(newSessionDate, initialLogDate)) {
+            setLogged(true)
+            console.log("dates are equal")
+        } else {
+            setLogged(false)
+            console.log("dates are not equal")
+        }
+    }
+
+    const isSameDate = (date1, date2) => {
+        const [month1, day1, year1]       = [date1.getMonth(), date1.getDate(), date1.getFullYear()];
+        const [month2, day2, year2]       = [date2.getMonth(), date2.getDate(), date2.getFullYear()];
+        
+        return month1 == month2 && day1 == day2 && year1 == year2
     }
 
     useEffect(() => {
@@ -231,9 +255,7 @@ export const SessionLogger = ({isCheckpoint, initSessionData, trainerSessionSele
                                                 <SmallAppButton
                                                     title={"Confirm"}
                                                     onPress={() => {
-                                                        setIsDateConfirmModalVisible(false);
-                                                        setLogged(false);
-                                                        setSessionDate(newSessionDate);
+                                                            confirmDate()
                                                     }}
                                                 />
                                                 <SmallAppButton

--- a/Pages/LogSessionPage.js
+++ b/Pages/LogSessionPage.js
@@ -121,7 +121,8 @@ export default class TrainerDieticianSessionWithSidebarPage extends Component{
     // formats the sidebar
     formatSessions(rawSessionsArray){
         let nextToLog = -1;
-        for(let i = 0; i < rawSessionsArray['trainerSessions'].length; i++){
+        let numSessions = rawSessionsArray['trainerSessions'].length;
+        for(let i = 0; i < numSessions; i++){    // for each session
             let isHighlighted = false;
             let hasLogDate = (rawSessionsArray['trainerSessions'][i]['initialLogDate']) != null;
 
@@ -130,7 +131,10 @@ export default class TrainerDieticianSessionWithSidebarPage extends Component{
                 isHighlighted = true
                 nextToLog = i + 1;
                 // dictates what session the sessionLogger will start at
-                this.state.sessionTrainer = i + 1
+                this.setState({sessionTrainer: i + 1 })
+            } else if (hasLogDate && i === numSessions - 1) {
+                isHighlighted = true;   // if all sessions are logged, show the last one
+                this.setState({ sessionTrainer: i + 1})
             }
             
            let sessionId = rawSessionsArray['trainerSessions'][i]['sessionIndexNumber']; 


### PR DESCRIPTION
1. Fixed bug where if all 24 sessions have been logged, no session is highlighted in the sidebar (so an error was thrown when selecting a different session)
2. fixed bug where the log session button turned green after confirming the date modal even if the date did not change